### PR TITLE
Add captcha to blog comment form

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,10 +38,16 @@ Run also migrations::
 
   python manage.py migrate captcha
 
+
 Usage
 -----
 
 Now you can create captchas for your forms in admin!
+
+Include the following option on your settings.py in order to add a captcha
+on the blog comments form. 
+
+  COMMENT_FORM_CLASS = "mezzacaptcha.forms.CaptchaThreadedCommentForm"
 
 For info on captcha configuration please see
 https://django-simple-captcha.readthedocs.org/en/latest/index.html

--- a/mezzacaptcha/forms.py
+++ b/mezzacaptcha/forms.py
@@ -1,0 +1,10 @@
+
+from django import forms
+from captcha.fields import CaptchaField
+from mezzanine.generic.forms import ThreadedCommentForm
+
+
+class CaptchaThreadedCommentForm(ThreadedCommentForm):
+    """ Adds a captcha field to the comment form in blog
+    """
+    captcha = CaptchaField()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 NAME = 'mezzanine-captcha'
-VERSION = '0.0.4'
+VERSION = '0.0.5'
 
 DESCR = """\
 Captcha field for Mezzanine. A hack which can break your fields if you're not careful.


### PR DESCRIPTION
It was not possible to include captcha field in the pre-defined form for blog comments. 
Now it will be possible if the user includes following option into the settings.py file

  COMMENT_FORM_CLASS = "mezzacaptcha.forms.CaptchaThreadedCommentForm"
